### PR TITLE
Add command-audit skill

### DIFF
--- a/skills/command-audit/SKILL.md
+++ b/skills/command-audit/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: command-audit
+description: Use this skill when the user wants to audit shell commands executed during a session, review dangerous command patterns, or check the command execution log for a project.
+---
+
+# Command Audit
+
+## Overview
+
+The command-audit skill logs all shell commands executed during a coding session and warns on dangerous operations. It maintains a per-project audit trail stored as JSONL files, enabling post-session review and analysis.
+
+Dangerous operations detected include:
+
+- Destructive file operations (`rm -rf /`, `rm -rf *`, `rm -rf ~`)
+- Destructive git commands (`git push --force`, `git push -f`, `git reset --hard`, `git clean -f`, `git checkout -- .`, `git branch -D`)
+- Database destruction (`DROP TABLE`, `DROP DATABASE`, `DROP SCHEMA`, `TRUNCATE TABLE`, `DELETE FROM`)
+- Unsafe permission changes (`chmod 777`, `chown -R`)
+- Disk/device operations (`dd of=/dev/`, `mkfs.`)
+- Process killing (`kill -9 -1`, `killall`)
+- Environment-breaking installs (`pip install --break-system-packages`, `npm cache clean --force`)
+
+## Workflow
+
+1. **Log a command**: Each shell command executed in the session is recorded with a timestamp, working directory, and project path.
+2. **Check for dangerous patterns**: Before or after execution, a command can be checked against the known dangerous patterns list. Matches are flagged with a warning status.
+3. **Review the audit log**: At any time, the full audit log for a project can be displayed, showing all commands and their statuses.
+4. **Generate a summary**: A session summary shows the total number of commands executed and how many triggered danger warnings.
+5. **Automatic log rotation**: Logs are capped at 1000 entries per project. When the limit is exceeded, the oldest entries are automatically trimmed.
+
+## Resources
+
+- `scripts/audit_commands.py` - Main audit script for logging, checking, and reviewing commands.
+- `references/config.md` - Configuration reference for dangerous patterns, storage location, and log rotation.
+- `agents/openai.yaml` - OpenAI Codex agent interface definition.

--- a/skills/command-audit/agents/openai.yaml
+++ b/skills/command-audit/agents/openai.yaml
@@ -1,0 +1,12 @@
+interface:
+  display_name: "Command Audit"
+  short_description: "Log and audit shell commands, detect dangerous patterns, and review session command history."
+  default_prompt: |
+    You are a command audit assistant. You help users:
+    - Log shell commands executed during coding sessions.
+    - Check commands against known dangerous patterns (rm -rf, git push --force, DROP TABLE, etc.).
+    - Review the audit log for a specific project.
+    - Generate session summaries showing total commands and warning counts.
+
+    Use the audit_commands.py script to perform these operations.
+    Always warn the user clearly when a dangerous command pattern is detected.

--- a/skills/command-audit/references/config.md
+++ b/skills/command-audit/references/config.md
@@ -1,0 +1,70 @@
+# Command Audit Configuration Reference
+
+## Storage Location
+
+Audit logs are stored in `~/.codex/command-audit/` as JSONL files. Each project gets its own log file named `<project-name>_<hash>.jsonl`, where the hash is derived from the absolute project path.
+
+The directory is created with `0700` permissions (owner-only access).
+
+## Log Format
+
+Each line in the JSONL file is a JSON object with the following fields:
+
+| Field                 | Type   | Description                                   |
+|-----------------------|--------|-----------------------------------------------|
+| `command`             | string | The shell command that was executed            |
+| `timestamp`           | string | UTC timestamp in ISO 8601 format              |
+| `cwd`                 | string | Working directory at the time of execution     |
+| `status`              | string | `executed` (safe) or `warned` (dangerous)      |
+| `matched_pattern`     | string | Regex pattern that matched (warned entries only)|
+| `pattern_description` | string | Human-readable description (warned entries only)|
+
+## Log Rotation
+
+- Maximum entries per log file: **1000**
+- When the limit is exceeded, the oldest entries are trimmed and only the most recent 1000 entries are retained.
+- Rotation is performed automatically after each write operation.
+
+## Dangerous Patterns
+
+The following patterns are checked (case-insensitive regex matching):
+
+### File Operations
+| Pattern | Description |
+|---------|-------------|
+| `rm -rf /` | Recursive force delete from root |
+| `rm -rf *` | Recursive force delete wildcard |
+| `rm -rf ~` | Recursive force delete home directory |
+
+### Git Operations
+| Pattern | Description |
+|---------|-------------|
+| `git push --force` | Force push to remote |
+| `git push -f` | Force push to remote (short flag) |
+| `git reset --hard` | Hard reset discarding changes |
+| `git clean -f` | Force clean untracked files |
+| `git checkout -- .` | Discard all working tree changes |
+| `git branch -D` | Force delete a branch |
+
+### Database Operations
+| Pattern | Description |
+|---------|-------------|
+| `DROP TABLE/DATABASE/SCHEMA` | Drop database objects |
+| `TRUNCATE TABLE` | Truncate table data |
+| `DELETE FROM` | Delete rows from table |
+
+### System Operations
+| Pattern | Description |
+|---------|-------------|
+| `chmod 777` | Set world-writable permissions |
+| `chown -R` | Recursive ownership change |
+| `dd of=/dev/` | Direct write to device |
+| `mkfs.` | Filesystem format |
+| `kill -9 -1` | Kill all processes |
+| `killall` | Kill all processes by name |
+
+### Environment Operations
+| Pattern | Description |
+|---------|-------------|
+| `pip install --break-system-packages` | Break system Python packages |
+| `npm cache clean --force` | Force clean npm cache |

--- a/skills/command-audit/scripts/audit_commands.py
+++ b/skills/command-audit/scripts/audit_commands.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""
+Command audit script: log shell commands, detect dangerous patterns,
+and review the audit log for a project.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Tuple
+
+# Maximum entries per project log file
+MAX_LOG_ENTRIES = 1000
+
+# Storage directory for audit logs
+LOG_DIR = Path.home() / ".codex" / "command-audit"
+
+# Dangerous command patterns (regex, case-insensitive)
+DANGEROUS_PATTERNS = [
+    # Destructive file operations
+    (r"rm\s+-[a-zA-Z]*r[a-zA-Z]*f|rm\s+-[a-zA-Z]*f[a-zA-Z]*r", "Recursive force delete"),
+    (r"rm\s+-rf\s+/", "Recursive force delete from root"),
+    (r"rm\s+-rf\s+\*", "Recursive force delete wildcard"),
+    (r"rm\s+-rf\s+~", "Recursive force delete home directory"),
+    # Git destructive operations
+    (r"git\s+push\s+.*--force", "Git force push"),
+    (r"git\s+push\s+-f\b", "Git force push (-f)"),
+    (r"git\s+reset\s+--hard", "Git hard reset"),
+    (r"git\s+clean\s+-[a-zA-Z]*f", "Git clean with force"),
+    (r"git\s+checkout\s+--\s+\.", "Git checkout discard all"),
+    (r"git\s+branch\s+-D", "Git branch force delete"),
+    # Database destructive operations
+    (r"DROP\s+(TABLE|DATABASE|SCHEMA)", "SQL DROP statement"),
+    (r"TRUNCATE\s+TABLE", "SQL TRUNCATE TABLE"),
+    (r"DELETE\s+FROM", "SQL DELETE FROM"),
+    # Unsafe permission changes
+    (r"chmod\s+777", "chmod 777 (world-writable)"),
+    (r"chown\s+-R", "Recursive chown"),
+    # Disk/device operations
+    (r"dd\s+.*of=/dev/", "dd write to device"),
+    (r"mkfs\.", "Filesystem format"),
+    # Process killing
+    (r"kill\s+-9\s+-1", "Kill all processes"),
+    (r"killall", "Kill all by name"),
+    # Environment-breaking operations
+    (r"pip\s+install\s+--break-system-packages", "pip break system packages"),
+    (r"npm\s+cache\s+clean\s+--force", "npm force cache clean"),
+]
+
+
+def get_project_id(repo_path: str) -> str:
+    """Generate a stable identifier for a project based on its path."""
+    resolved = str(Path(repo_path).resolve())
+    return hashlib.sha256(resolved.encode()).hexdigest()[:16]
+
+
+def get_log_path(repo_path: str) -> Path:
+    """Return the JSONL log file path for a given project."""
+    project_id = get_project_id(repo_path)
+    project_name = Path(repo_path).resolve().name
+    safe_name = re.sub(r"[^a-zA-Z0-9_-]", "_", project_name)[:50]
+    return LOG_DIR / f"{safe_name}_{project_id}.jsonl"
+
+
+def ensure_log_dir() -> None:
+    """Create the log directory if it does not exist."""
+    LOG_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(LOG_DIR, 0o700)
+    except OSError:
+        pass
+
+
+def trim_log(log_path: Path) -> None:
+    """Trim the log file to MAX_LOG_ENTRIES, removing oldest entries."""
+    if not log_path.is_file():
+        return
+    try:
+        with open(log_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        if len(lines) > MAX_LOG_ENTRIES:
+            lines = lines[-MAX_LOG_ENTRIES:]
+            with open(log_path, "w", encoding="utf-8") as f:
+                f.writelines(lines)
+    except OSError:
+        pass
+
+
+def log_command(repo_path: str, command: str) -> None:
+    """Log a command execution to the project audit log."""
+    ensure_log_dir()
+    log_path = get_log_path(repo_path)
+
+    entry = {
+        "command": command,
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "cwd": str(Path(repo_path).resolve()),
+        "status": "executed",
+    }
+
+    # Check if the command is dangerous and annotate
+    match = check_dangerous_pattern(command)
+    if match:
+        entry["status"] = "warned"
+        entry["matched_pattern"] = match[0]
+        entry["pattern_description"] = match[1]
+
+    try:
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError as e:
+        print(f"Error writing log: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    trim_log(log_path)
+
+    if entry["status"] == "warned":
+        print(f"WARNING: Dangerous command detected - {match[1]}")
+        print(f"  Command: {command}")
+    else:
+        print(f"Logged: {command}")
+
+
+def check_dangerous_pattern(command: str) -> Optional[Tuple[str, str]]:
+    """Check if a command matches any dangerous pattern.
+
+    Returns (pattern, description) if matched, None otherwise.
+    """
+    for pattern, description in DANGEROUS_PATTERNS:
+        if re.search(pattern, command, re.IGNORECASE):
+            return (pattern, description)
+    return None
+
+
+def check_dangerous(command: str) -> None:
+    """Check a command against dangerous patterns and report."""
+    match = check_dangerous_pattern(command)
+    if match:
+        print(f"DANGEROUS: {match[1]}")
+        print(f"  Pattern: {match[0]}")
+        print(f"  Command: {command}")
+        sys.exit(1)
+    else:
+        print(f"OK: No dangerous patterns detected in: {command}")
+
+
+def show_log(repo_path: str) -> None:
+    """Display the audit log for a project."""
+    log_path = get_log_path(repo_path)
+    if not log_path.is_file():
+        print(f"No audit log found for: {repo_path}")
+        return
+
+    try:
+        with open(log_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError as e:
+        print(f"Error reading log: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not lines:
+        print(f"Audit log is empty for: {repo_path}")
+        return
+
+    print(f"=== Command Audit Log: {Path(repo_path).resolve().name} ===")
+    print(f"Log file: {log_path}")
+    print(f"Entries: {len(lines)}")
+    print()
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+            status = entry.get("status", "unknown")
+            ts = entry.get("timestamp", "?")
+            cmd = entry.get("command", "?")
+            marker = "[WARN]" if status == "warned" else "[OK]  "
+            print(f"  {marker} {ts}  {cmd}")
+            if status == "warned" and "pattern_description" in entry:
+                print(f"         Reason: {entry['pattern_description']}")
+        except json.JSONDecodeError:
+            continue
+
+    print()
+    print("=== End of Audit Log ===")
+
+
+def show_summary(repo_path: str) -> None:
+    """Show a session summary for a project."""
+    log_path = get_log_path(repo_path)
+    if not log_path.is_file():
+        print(f"No audit log found for: {repo_path}")
+        return
+
+    total = 0
+    warned = 0
+
+    try:
+        with open(log_path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    total += 1
+                    if entry.get("status") == "warned":
+                        warned += 1
+                except json.JSONDecodeError:
+                    continue
+    except OSError as e:
+        print(f"Error reading log: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"=== Command Audit Summary: {Path(repo_path).resolve().name} ===")
+    print(f"  Total commands logged: {total}")
+    print(f"  Dangerous warnings:    {warned}")
+    print(f"  Safe commands:         {total - warned}")
+    if total > 0:
+        pct = (warned / total) * 100
+        print(f"  Warning rate:          {pct:.1f}%")
+    print("=== End of Summary ===")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit shell commands: log, check, and review."
+    )
+    parser.add_argument(
+        "--repo",
+        type=str,
+        required=True,
+        help="Project root path.",
+    )
+    parser.add_argument(
+        "--log-command",
+        type=str,
+        default=None,
+        help="Log a command execution.",
+    )
+    parser.add_argument(
+        "--check-dangerous",
+        type=str,
+        default=None,
+        help="Check if a command matches dangerous patterns.",
+    )
+    parser.add_argument(
+        "--show-log",
+        action="store_true",
+        default=False,
+        help="Display the audit log for this project.",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        default=False,
+        help="Show session summary (total commands, warned count).",
+    )
+
+    args = parser.parse_args()
+
+    actions = sum([
+        args.log_command is not None,
+        args.check_dangerous is not None,
+        args.show_log,
+        args.summary,
+    ])
+
+    if actions == 0:
+        parser.error("No action specified. Use --log-command, --check-dangerous, --show-log, or --summary.")
+    if actions > 1:
+        parser.error("Only one action can be specified at a time.")
+
+    if args.log_command is not None:
+        log_command(args.repo, args.log_command)
+    elif args.check_dangerous is not None:
+        check_dangerous(args.check_dangerous)
+    elif args.show_log:
+        show_log(args.repo)
+    elif args.summary:
+        show_summary(args.repo)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- claude_pluginのcommand-auditプラグインをCodex skill形式に移植
- シェルコマンドの監査ログと危険コマンド検出
- SKILL.md, agents/openai.yaml, scripts, references/config.md を含む

## Test plan
- [ ] scripts が正常に実行可能であること
- [ ] SKILL.md のフロントマターが正しいこと
- [ ] agents/openai.yaml の形式が正しいこと
- [ ] references/config.md の内容が正確であること

## AI Review
- [x] Codex などによるレビュー実施済み
- [x] 優先度「高」の指摘事項は全て解消済み