### PR TITLE
Add session-handoff skill

### DIFF
--- a/skills/session-handoff/SKILL.md
+++ b/skills/session-handoff/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: session-handoff
+description: Use this skill when the user wants to generate handoff notes for session continuity, load previous session context, or transfer work state between Codex sessions.
+---
+
+# Session Handoff
+
+## Overview
+
+Session Handoff enables seamless context transfer between Codex sessions. At the end of a session, it generates structured handoff notes capturing current work state including git branch, uncommitted changes, and recent commit history. When starting a new session, these notes can be loaded to restore full context and resume work without losing momentum.
+
+## Workflow
+
+1. **Generate** -- Run `session_handoff.py --repo <path> --action generate` to capture the current session state. The script records the git branch, working tree status, and recent commits into a timestamped JSON file stored in `~/.codex/session-handoff/`.
+
+2. **Load** -- Run `session_handoff.py --repo <path> --action load --latest` (or `--session-id <id>`) at the start of a new session to restore previous context. The loaded note is printed as structured output for the agent to consume.
+
+3. **List** -- Run `session_handoff.py --repo <path> --action list` to display available handoff notes for the current project. Up to 10 notes are shown, sorted by most recent first.
+
+4. **Auto-cleanup** -- Notes older than 30 days are automatically removed during any action to keep storage tidy.
+
+## Resources
+
+- `scripts/session_handoff.py` -- Main script for generate / load / list operations.
+- `references/config.md` -- Storage location, JSON format, and cleanup policy documentation.
+- `agents/openai.yaml` -- Agent interface definition.

--- a/skills/session-handoff/agents/openai.yaml
+++ b/skills/session-handoff/agents/openai.yaml
@@ -1,0 +1,21 @@
+name: session-handoff
+description: >
+  Generate, load, or list session handoff notes for seamless context transfer
+  between Codex sessions. Captures git state, recent commits, and working tree
+  status so a new session can resume where the previous one left off.
+instructions: |
+  Use the session_handoff.py script to manage handoff notes.
+
+  To generate a handoff note at the end of a session:
+    python3 scripts/session_handoff.py --repo <project-root> --action generate
+
+  To load a previous session's context:
+    python3 scripts/session_handoff.py --repo <project-root> --action load --latest
+    python3 scripts/session_handoff.py --repo <project-root> --action load --session-id <id>
+
+  To list available handoff notes:
+    python3 scripts/session_handoff.py --repo <project-root> --action list
+
+  Notes are stored as JSON in ~/.codex/session-handoff/ and auto-cleaned after 30 days.
+tools:
+  - type: bash

--- a/skills/session-handoff/references/config.md
+++ b/skills/session-handoff/references/config.md
@@ -1,0 +1,41 @@
+# Session Handoff Configuration
+
+## Storage Location
+
+Handoff notes are stored in `~/.codex/session-handoff/`. The directory is created automatically on the first `generate` action.
+
+Each note is saved as a separate JSON file named `<session_id>.json`.
+
+## JSON Format
+
+```json
+{
+  "session_id": "a1b2c3d4e5f6",
+  "project_path": "/absolute/path/to/project",
+  "project_key": "_absolute_path_to_project",
+  "timestamp": "2026-03-22T12:00:00+00:00",
+  "git_branch": "main",
+  "git_status": "M src/app.py\n?? new_file.txt",
+  "recent_commits": "abc1234 Fix login bug\ndef5678 Add user model"
+}
+```
+
+### Fields
+
+| Field | Description |
+|---|---|
+| `session_id` | Unique 12-character hex identifier for the session note. |
+| `project_path` | Absolute, resolved path to the project root. |
+| `project_key` | Filesystem-safe key derived from the project path; used to filter notes per project. |
+| `timestamp` | ISO 8601 UTC timestamp of when the note was generated. |
+| `git_branch` | Current branch at the time of generation. |
+| `git_status` | Output of `git status --short` (uncommitted changes). |
+| `recent_commits` | Last 10 commits from `git log --oneline -10`. |
+
+## Cleanup Policy
+
+Notes older than **30 days** are automatically deleted whenever any action (`generate`, `load`, `list`) is executed. This keeps the storage directory manageable without requiring manual maintenance.
+
+## Limits
+
+- The `list` action displays a maximum of **10** notes per project, sorted newest-first.

--- a/skills/session-handoff/scripts/session_handoff.py
+++ b/skills/session-handoff/scripts/session_handoff.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Session Handoff: generate, load, and list session handoff notes for Codex."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+STORE_DIR = Path.home() / ".codex" / "session-handoff"
+CLEANUP_DAYS = 30
+MAX_LIST = 10
+
+
+def _run_git(repo: str, *args: str) -> str:
+    """Run a git command in the given repo and return stripped stdout."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo] + list(args),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return ""
+
+
+def _project_key(repo: str) -> str:
+    """Return a stable key derived from the absolute repo path."""
+    return os.path.realpath(repo).replace("/", "_").strip("_")
+
+
+def _cleanup_old_notes() -> None:
+    """Remove handoff notes older than CLEANUP_DAYS."""
+    if not STORE_DIR.exists():
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=CLEANUP_DAYS)
+    for f in STORE_DIR.glob("*.json"):
+        try:
+            data = json.loads(f.read_text())
+            ts = datetime.fromisoformat(data.get("timestamp", ""))
+            if ts < cutoff:
+                f.unlink()
+        except (json.JSONDecodeError, ValueError, OSError):
+            pass
+
+
+def _notes_for_project(repo: str) -> list[Path]:
+    """Return note paths for the given project, newest first."""
+    if not STORE_DIR.exists():
+        return []
+    key = _project_key(repo)
+    notes: list[tuple[str, Path]] = []
+    for f in STORE_DIR.glob("*.json"):
+        try:
+            data = json.loads(f.read_text())
+            if data.get("project_key") == key:
+                notes.append((data.get("timestamp", ""), f))
+        except (json.JSONDecodeError, OSError):
+            pass
+    notes.sort(key=lambda x: x[0], reverse=True)
+    return [p for _, p in notes]
+
+
+# ── Actions ──────────────────────────────────────────────────────────────
+
+
+def action_generate(repo: str) -> None:
+    """Generate a handoff note capturing the current git state."""
+    STORE_DIR.mkdir(parents=True, exist_ok=True)
+    _cleanup_old_notes()
+
+    branch = _run_git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    status = _run_git(repo, "status", "--short")
+    recent_commits = _run_git(repo, "log", "--oneline", "-10")
+
+    session_id = uuid.uuid4().hex[:12]
+    note = {
+        "session_id": session_id,
+        "project_path": os.path.realpath(repo),
+        "project_key": _project_key(repo),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "git_branch": branch,
+        "git_status": status,
+        "recent_commits": recent_commits,
+    }
+
+    out_path = STORE_DIR / f"{session_id}.json"
+    out_path.write_text(json.dumps(note, indent=2) + "\n")
+    print(json.dumps(note, indent=2))
+
+
+def action_load(repo: str, session_id: str | None, latest: bool) -> None:
+    """Load a handoff note by session-id or latest."""
+    _cleanup_old_notes()
+
+    if latest:
+        notes = _notes_for_project(repo)
+        if not notes:
+            print("No handoff notes found for this project.", file=sys.stderr)
+            sys.exit(1)
+        data = json.loads(notes[0].read_text())
+    elif session_id:
+        target = STORE_DIR / f"{session_id}.json"
+        if not target.exists():
+            print(f"Session {session_id} not found.", file=sys.stderr)
+            sys.exit(1)
+        data = json.loads(target.read_text())
+    else:
+        print("Specify --session-id <id> or --latest.", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(data, indent=2))
+
+
+def action_list(repo: str) -> None:
+    """List available handoff notes for the project."""
+    _cleanup_old_notes()
+    notes = _notes_for_project(repo)
+    if not notes:
+        print("No handoff notes found for this project.")
+        return
+
+    for note_path in notes[:MAX_LIST]:
+        data = json.loads(note_path.read_text())
+        ts = data.get("timestamp", "unknown")
+        sid = data.get("session_id", "unknown")
+        branch = data.get("git_branch", "unknown")
+        print(f"  {sid}  {ts}  branch:{branch}")
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Session Handoff for Codex")
+    parser.add_argument("--repo", required=True, help="Project root path")
+    parser.add_argument(
+        "--action",
+        required=True,
+        choices=["generate", "load", "list"],
+        help="Action to perform",
+    )
+    parser.add_argument("--session-id", default=None, help="Session ID to load")
+    parser.add_argument(
+        "--latest", action="store_true", help="Load the latest handoff note"
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.repo):
+        print(f"Error: {args.repo} is not a valid directory.", file=sys.stderr)
+        sys.exit(1)
+
+    if args.action == "generate":
+        action_generate(args.repo)
+    elif args.action == "load":
+        action_load(args.repo, args.session_id, args.latest)
+    elif args.action == "list":
+        action_list(args.repo)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- claude_pluginのsession-handoffプラグインをCodex skill形式に移植
- セッション引き継ぎメモの生成・読込・管理
- SKILL.md, agents/openai.yaml, scripts, references/config.md を含む

## Test plan
- [ ] scripts が正常に実行可能であること
- [ ] SKILL.md のフロントマターが正しいこと
- [ ] agents/openai.yaml の形式が正しいこと
- [ ] references/config.md の内容が正確であること

## AI Review
- [x] Codex などによるレビュー実施済み
- [x] 優先度「高」の指摘事項は全て解消済み